### PR TITLE
Added AWS SDK setting of region, with support for endpoint override.

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientImpl.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientImpl.java
@@ -18,6 +18,7 @@ package com.netflix.exhibitor.core.s3;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
 import org.slf4j.Logger;
@@ -244,6 +245,10 @@ public class S3ClientImpl implements S3Client
     private AmazonS3Client createClient(AWSCredentialsProvider awsCredentialProvider, BasicAWSCredentials basicAWSCredentials, S3ClientConfig clientConfig)
     {
         AmazonS3Client localClient;
+
+        // Setting endpoint property will always supersede region setting.
+        String endpoint = System.getProperty("exhibitor-s3-endpoint");
+
         if ( awsCredentialProvider != null )
         {
             if ( clientConfig != null )
@@ -276,6 +281,17 @@ public class S3ClientImpl implements S3Client
             {
                 localClient = new AmazonS3Client();
             }
+        }
+
+        if ( endpoint != null )
+        {
+            localClient.setEndpoint(endpoint);
+            log.info("Setting S3 endpoint to: " + endpoint);
+        }
+        else if ( s3Region != null)
+        {
+            localClient.setRegion(RegionUtils.getRegion(s3Region));
+            log.info("Setting S3 region to: " + s3Region);
         }
 
         return localClient;


### PR DESCRIPTION
This change will maintain support for explicit endpoint override, as well as using the proper AWS SDK setRegion method. setRegion on AmazonS3Client is deprecated, but the other option of using AmazonS3ClientBuilder would have required a larger change.